### PR TITLE
Configure Postgres to work with Debezium

### DIFF
--- a/db/local-db.yml
+++ b/db/local-db.yml
@@ -11,4 +11,4 @@ services:
       POSTGRES_DB: root
       POSTGRES_USER: root
       POSTGRES_PASSWORD: root
-    command: -c 'max_connections=512'
+    command: -c 'max_connections=512' -c 'wal_level=logical'


### PR DESCRIPTION
Set `wal_level` to `logical`, which is required for Debezium to be able to read the Postgres WAL.

To check if it's applied correctly, after restarting the DB, run `SHOW wal_level;` which should return `logical`.