### PR TITLE
Add pgAdmin

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,4 +58,7 @@ curl -X POST http://localhost:3000/eservices \
 ```
 
 You should see the event being processed by the consumer and the read model being updated.
+
 You can verify this by using Mongo Express, which is being started alongside the consumer and is available at http://localhost:8081/db/readmodel.
+
+Similarly, there is a Postgres web client that can be used to inspect the event stores at http://localhost:8082.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -51,6 +51,7 @@ services:
     environment:
       MONGO_INITDB_ROOT_USERNAME: root
       MONGO_INITDB_ROOT_PASSWORD: example
+
   # Mongo Express is a web-based MongoDB admin interface, included for convenience
   mongo-express:
     image: mongo-express
@@ -63,3 +64,28 @@ services:
     depends_on:
       - readmodel
     restart: always
+
+  # PGAdmin is a web-based PostgreSQL admin interface, included for convenience
+  pg-admin:
+    image: dpage/pgadmin4
+    ports:
+      - 8082:80
+    environment:
+      PGADMIN_DEFAULT_EMAIL: root@example.com
+      PGADMIN_DEFAULT_PASSWORD: example
+      PGADMIN_CONFIG_SERVER_MODE: "False"
+      PGADMIN_CONFIG_MASTER_PASSWORD_REQUIRED: "False"
+    restart: always
+    volumes:
+      - ./pg-servers.json:/pgadmin4/servers.json
+      - ./pg-pass:/pgadmin4/pgpass
+    # see https://stackoverflow.com/a/69475874/846273
+    entrypoint: >
+      /bin/sh -c "
+      mkdir -m 700 /var/lib/pgadmin/storage/root_example.com;
+      chown -R pgadmin:pgadmin /var/lib/pgadmin/storage/root_example.com;
+      cp -prv /pgadmin4/pgpass /var/lib/pgadmin/storage/root_example.com/;
+      chmod 600 /var/lib/pgadmin/storage/root_example.com/pgpass;
+      /entrypoint.sh
+      "
+

--- a/docker/pg-pass
+++ b/docker/pg-pass
@@ -1,0 +1,2 @@
+# hostname:port:database:username:password
+catalog-event-store:5432:root:root:root

--- a/docker/pg-servers.json
+++ b/docker/pg-servers.json
@@ -1,0 +1,14 @@
+{
+  "Servers": {
+    "1": {
+      "Name": "Catalog Event Store",
+      "Group": "Event Stores",
+      "Host": "catalog-event-store",
+      "Port": 5432,
+      "Username": "root",
+      "PassFile": "/pgadmin4/pgpass",
+      "SSLMode": "prefer",
+      "MaintenanceDB": "postgres"
+    }
+  }
+}

--- a/packages/catalog-process/scripts/db-destroy.sh
+++ b/packages/catalog-process/scripts/db-destroy.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker compose -f ../../docker/docker-compose.yml down catalog-event-store
+docker compose -f ../../docker/docker-compose.yml down catalog-event-store pg-admin

--- a/packages/catalog-process/scripts/db-start.sh
+++ b/packages/catalog-process/scripts/db-start.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker compose -f ../../docker/docker-compose.yml up -d  catalog-event-store
+docker compose -f ../../docker/docker-compose.yml up -d  catalog-event-store pg-admin

--- a/packages/catalog-process/scripts/db-stop.sh
+++ b/packages/catalog-process/scripts/db-stop.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker compose -f ../../docker/docker-compose.yml stop catalog-event-store
+docker compose -f ../../docker/docker-compose.yml stop catalog-event-store pg-admin


### PR DESCRIPTION
Questa PR aggiunge un pgAdmin preconfigurato esposto sulla 8082, che è utile per ispezionare gli event store durante lo sviluppo locale